### PR TITLE
Runs with Bio =>1.82

### DIFF
--- a/micomplete/__init__.py
+++ b/micomplete/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) Eric Hugoson.
 # See LICENSE for details.
 
-__version__ = '1.1.1'
+__version__ = '1.1.2'
 __all__ = ['completeness', 'linkageanalysis', 'parseseqs', 'micomplete']
 from .completeness import calcCompleteness
 from .linkageanalysis import linkageAnalysis

--- a/micomplete/micomplete.py
+++ b/micomplete/micomplete.py
@@ -46,7 +46,7 @@ except ImportError:
 try:
     from micomplete import __version__
 except ImportError:
-    __version__ = "1.1.1"
+    __version__ = "1.1.2"
 try:
     from micomplete import parseSeqStats
     from micomplete import linkageAnalysis

--- a/micomplete/parseseqs.py
+++ b/micomplete/parseseqs.py
@@ -9,9 +9,10 @@ from __future__ import division, print_function
 import logging
 import re
 
+from packaging import version 
+import Bio
 from Bio import SeqIO
-from Bio.SeqUtils import GC
-
+from Bio import SeqUtils
 
 class parseSeqStats():
     def __init__(self, seq, base_name, seq_type, logger=None):
@@ -76,7 +77,10 @@ class parseSeqStats():
             except AttributeError:
                 pass
             # implement memory-efficient method here
-            gc_content = round(GC(''.join(str(total_fasta))), 2)
+            if version.parse(Bio.__version__) <= version.parse("1.80"):
+                gc_content = round(SeqUtils.GC(''.join(str(total_fasta))), 2)
+            else:
+                gc_content = SeqUtils.gc_fraction(''.join(total_fasta) * 100)
         seq_length = sum(all_lengths)
         return seq_length, all_lengths, gc_content
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open('README.rst', mode='r') as f:
     l_description = f.read()
 
 setup(name='micomplete',
-        version='1.1.1',
+        version='1.1.2',
         description='Quality control of assembled genomes',
         long_description=l_description,
         url='https://bitbucket.org/evolegiolab/micomplete',


### PR DESCRIPTION
`Bio.SeqUtils.GC` was deprecated in `Biopython` 1.80 and retired in 1.82. Instead, `Bio.SeqUtils.gc_fraction` was introduced in 1.80. This PR checks the version of Biopython and chooses the correct function to use. 